### PR TITLE
Chk 733 obsfuscate mail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.ninja-squad</groupId>
+            <artifactId>springmockk</artifactId>
+            <version>3.1.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito.kotlin</groupId>
             <artifactId>mockito-kotlin</artifactId>
             <version>${mockito-kotlin.version}</version>

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/requests/exceptions/ValidationFailedException.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/requests/exceptions/ValidationFailedException.kt
@@ -1,0 +1,54 @@
+package it.pagopa.ecommerce.payment.requests.exceptions
+
+import org.springframework.util.ObjectUtils
+import org.springframework.validation.BindingResult
+import org.springframework.validation.FieldError
+import java.util.regex.Pattern
+
+class ValidationFailedException(errorMessage: String) :
+    RuntimeException(errorMessage) {
+
+    companion object {
+        fun fromBindingResult(
+            bindingResult: BindingResult,
+            fieldsToObfuscate: Set<String>
+        ): ValidationFailedException {
+            val fieldSearchPattern: Pattern = Pattern.compile(
+                ".*%s.*".format(
+                    fieldsToObfuscate.joinToString(separator = "|")
+                )
+            )
+            return ValidationFailedException(
+                logErrors(
+                    bindingResult,
+                    fieldSearchPattern
+                )
+            )
+        }
+
+        private fun logErrors(bindingResult: BindingResult, fieldSearchPattern: Pattern): String {
+            val toLog =
+                StringBuilder("Input request validation exception. Error count: (${bindingResult.allErrors.size})")
+            toLog.append(System.lineSeparator());
+            for (error in bindingResult.allErrors) {
+                if (error is FieldError) {
+                    toLog.append(logField(error, fieldSearchPattern));
+                } else {
+                    toLog.append(error.toString())
+                }
+                toLog.append(System.lineSeparator());
+            }
+            return toLog.toString()
+        }
+
+        private fun logField(fieldError: FieldError, fieldSearchPattern: Pattern): String {
+            val rejectedValue: Any? =
+                if (fieldSearchPattern.matcher(fieldError.field).find()) {
+                    "***OBFUSCATED***"
+                } else {
+                    fieldError.rejectedValue
+                }
+            return "Field [${fieldError.field}]: rejected value [${ObjectUtils.nullSafeToString(rejectedValue)}]; reason: [${fieldError.defaultMessage}]";
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,5 @@ nodo.nodeforpsp.uri=${NODE_FOR_PSP_URI}
 nodo.readTimeout=${NODO_READ_TIMEOUT}
 nodo.connectionTimeout=${NODO_CONNECTION_TIMEOUT}
 nodo.connection.string=${NODO_CONNECTION_STRING}
+#fields to be obfuscated in case of bean validation failure
+fields_to_obscure={'emailNotice'}

--- a/src/test/kotlin/it/pagopa/ecommerce/payment/requests/controllers/CartsControllerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/payment/requests/controllers/CartsControllerTests.kt
@@ -13,7 +13,7 @@ import it.pagopa.ecommerce.payment.requests.validation.BeanValidationConfigurati
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.mockito.BDDMockito.given
+import org.mockito.BDDMockito.*
 import org.mockito.InjectMocks
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
@@ -100,6 +100,7 @@ class CartsControllerTests {
             .expectStatus().isBadRequest
             .expectBody().json(objectMapper.writeValueAsString(errorResponse))
     }
+
 
     @Test
     fun `controller throw generic exception`() = runTest {

--- a/src/test/kotlin/it/pagopa/ecommerce/payment/requests/errorhandling/ExceptionHandlerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/payment/requests/errorhandling/ExceptionHandlerTests.kt
@@ -1,0 +1,67 @@
+package it.pagopa.ecommerce.payment.requests.errorhandling
+
+import io.mockk.mockkObject
+import it.pagopa.ecommerce.payment.requests.exceptions.ValidationFailedException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.*
+import org.springframework.core.MethodParameter
+import org.springframework.test.context.TestPropertySource
+import org.springframework.validation.BindingResult
+import org.springframework.validation.DirectFieldBindingResult
+import org.springframework.validation.FieldError
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.support.WebExchangeBindException
+
+@ExtendWith(MockitoExtension::class)
+@TestPropertySource(locations = ["classpath:application.test.properties"])
+class ExceptionHandlerTests {
+
+    private val fieldsToObfuscate = setOf("emailNotice")
+
+    private val validationFailedExceptionCompanionObject: ValidationFailedException.Companion = mock()
+
+
+    private val exceptionHandler = ExceptionHandler(fieldsToObfuscate)
+
+    @Test
+    fun `handle request validation exception should wrap WebExchangeBindException exception`() {
+        val bindingResult: BindingResult = DirectFieldBindingResult("", "cartsRequest")
+        val fieldError = FieldError("testObject", "field", "testFieldValue", true, null, null, null)
+        bindingResult.addError(fieldError)
+        given(validationFailedExceptionCompanionObject.fromBindingResult(any(), any())).willReturn(
+            ValidationFailedException("test")
+        )
+        val methodParameter = MethodParameter.forExecutable(String::class.java.getMethod("toString"), -1)
+        val webExchangeBindException = WebExchangeBindException(methodParameter, bindingResult)
+        mockkObject(ValidationFailedException.Companion)
+        exceptionHandler.handleRequestValidationException(webExchangeBindException)
+        io.mockk.verify(exactly = 1) {
+            ValidationFailedException.Companion.fromBindingResult(
+                any(),
+                any()
+            )
+        }
+    }
+
+    @Test
+    fun `handle request validation exception should wrap MethodArgumentNotValidException exceptions`() {
+        val bindingResult: BindingResult = DirectFieldBindingResult("", "cartsRequest")
+        val fieldError = FieldError("testObject", "field", "testFieldValue", true, null, null, null)
+        bindingResult.addError(fieldError)
+        given(validationFailedExceptionCompanionObject.fromBindingResult(any(), any())).willReturn(
+            ValidationFailedException("test")
+        )
+        val methodParameter = MethodParameter.forExecutable(String::class.java.getMethod("toString"), -1)
+        val methodArgumentNotValidException = MethodArgumentNotValidException(methodParameter, bindingResult)
+        mockkObject(ValidationFailedException.Companion)
+        exceptionHandler.handleRequestValidationException(methodArgumentNotValidException)
+        io.mockk.verify(exactly = 1) {
+            ValidationFailedException.Companion.fromBindingResult(
+                any(),
+                any()
+            )
+        }
+    }
+}

--- a/src/test/kotlin/it/pagopa/ecommerce/payment/requests/exceptions/ValidationFailedExceptionTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/payment/requests/exceptions/ValidationFailedExceptionTests.kt
@@ -1,0 +1,30 @@
+package it.pagopa.ecommerce.payment.requests.exceptions
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.validation.BindingResult
+import org.springframework.validation.DirectFieldBindingResult
+import org.springframework.validation.FieldError
+
+class ValidationFailedExceptionTests {
+
+    private val fieldsToObfuscate = setOf("emailNotice")
+
+
+    @Test
+    fun `validation request should not log sensitive data`() {
+        val bindingResult: BindingResult = DirectFieldBindingResult("", "cartsRequest")
+        val fieldErrorMail = FieldError("", "emailNotice", "test@test.it.", true, null, null, null)
+        val fieldErrorFiscalCode = FieldError("", "fiscalCode", "testFiscalCode", true, null, null, null)
+        bindingResult.addError(fieldErrorMail)
+        bindingResult.addError(fieldErrorFiscalCode)
+        val validationFailedException = ValidationFailedException.fromBindingResult(bindingResult, fieldsToObfuscate)
+        println(validationFailedException.message)
+        val emailPresent: Boolean =
+            validationFailedException.message?.contains("rejected value [test@test.it.]") ?: false
+        val fiscalCodePresent: Boolean =
+            validationFailedException.message?.contains("rejected value [testFiscalCode]") ?: false
+        assertTrue(!emailPresent)
+        assertTrue(fiscalCodePresent)
+    }
+}

--- a/src/test/kotlin/it/pagopa/ecommerce/payment/requests/tests/utils/CartRequests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/payment/requests/tests/utils/CartRequests.kt
@@ -63,4 +63,22 @@ object CartRequests {
             )
         )
     }
+
+    fun invalidEmailRequest(): CartRequestDto {
+        return CartRequestDto(
+            paymentNotices = listOf(
+                PaymentNoticeDto(
+                    noticeNumber = "302000100440009424",
+                    fiscalCode = "77777777777",
+                    amount = 10000
+                )
+            ),
+            returnurls = CartRequestReturnurlsDto(
+                returnOkUrl = URI("www.comune.di.prova.it/pagopa/success.html"),
+                returnCancelUrl = URI("www.comune.di.prova.it/pagopa/cancel.html"),
+                returnErrorUrl = URI("www.comune.di.prova.it/pagopa/error.html"),
+            ),
+            emailNotice = "my_email@mail.it."
+        )
+    }
 }

--- a/src/test/kotlin/it/pagopa/ecommerce/payment/requests/tests/utils/CartRequests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/payment/requests/tests/utils/CartRequests.kt
@@ -63,22 +63,4 @@ object CartRequests {
             )
         )
     }
-
-    fun invalidEmailRequest(): CartRequestDto {
-        return CartRequestDto(
-            paymentNotices = listOf(
-                PaymentNoticeDto(
-                    noticeNumber = "302000100440009424",
-                    fiscalCode = "77777777777",
-                    amount = 10000
-                )
-            ),
-            returnurls = CartRequestReturnurlsDto(
-                returnOkUrl = URI("www.comune.di.prova.it/pagopa/success.html"),
-                returnCancelUrl = URI("www.comune.di.prova.it/pagopa/cancel.html"),
-                returnErrorUrl = URI("www.comune.di.prova.it/pagopa/error.html"),
-            ),
-            emailNotice = "my_email@mail.it."
-        )
-    }
 }

--- a/src/test/resources/application.test.properties
+++ b/src/test/resources/application.test.properties
@@ -10,3 +10,5 @@ spring.redis.host=http://redishost
 spring.redis.password=redispassword
 spring.redis.port=1234
 spring.redis.ssl=true
+#fields to be obfuscated in case of bean validation failure
+fields_to_obscure={'emailNotice'}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Implemented parametric field obfuscation for logging bean validation exceptions.
Obfuscation is performed checking if the field to be log is included into a parametric field to obfuscate list and obfuscate it's content iff the field name is included into that list.
#### Motivation and Context
Carts request contains emailNotice field that, in case is not a valid email, will trigger bean validation failure.
That can expose into applicative logs partial/complete user email.
For example, for a request where emailNotice field is valued  _email@email.it._ will result into complete user email exposure.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local test. Tests have been performed sending request with invalid email field and checking that the sent email was not present into applicative logs
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.