### PR TITLE
feat: changed POST carts location URL to the created cart

### DIFF
--- a/api-spec/payment-requests-api.yaml
+++ b/api-spec/payment-requests-api.yaml
@@ -461,9 +461,15 @@ components:
           maxItems: 5
           example:
             - noticeNumber: "302012387654312384"
-              fiscalCode: "7777777777"
+              fiscalCode: "77777777777"
+              amount: 10000
+              companyName: "companyName"
+              description: "description"
             - noticeNumber: "302012387654312385"
-              fiscalCode: "7777777777"
+              fiscalCode: "77777777777"
+              amount: 5000
+              companyName: "companyName"
+              description: "description"
         returnUrls:
           type: object
           required:
@@ -489,6 +495,8 @@ components:
         - noticeNumber
         - fiscalCode
         - amount
+        - companyName
+        - description
       properties:
         noticeNumber:
           type: string

--- a/api-spec/payment-requests-api.yaml
+++ b/api-spec/payment-requests-api.yaml
@@ -100,6 +100,7 @@ paths:
           description: Unique identifier for cart
           schema:
             type: string
+            format: uuid
           required: true
       responses:
         '200':

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/requests/controllers/CartsController.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/requests/controllers/CartsController.kt
@@ -25,7 +25,7 @@ class CartsController(
     }
 
 
-    override suspend fun getCarts(idCart: String): ResponseEntity<CartRequestDto> {
+    override suspend fun getCarts(idCart: java.util.UUID): ResponseEntity<CartRequestDto> {
         return ResponseEntity.ok(
             cartService.getCart(idCart)
         )

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/requests/exceptions/InvalidRptException.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/requests/exceptions/InvalidRptException.kt
@@ -1,0 +1,14 @@
+package it.pagopa.ecommerce.payment.requests.exceptions
+
+import it.pagopa.ecommerce.payment.requests.errorhandling.ApiError
+import org.springframework.http.HttpStatus
+
+class InvalidRptException(rptId: String) : ApiError("Invalid input rpt id: [$rptId]") {
+    override fun toRestException(): RestApiException =
+        RestApiException(
+            httpStatus = HttpStatus.BAD_REQUEST,
+            title = "Invalid RPT id",
+            description = this.message ?: ""
+        )
+
+}

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/requests/repositories/CartInfo.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/requests/repositories/CartInfo.kt
@@ -3,7 +3,6 @@ package it.pagopa.ecommerce.payment.requests.repositories
 import org.springframework.data.annotation.Id
 import org.springframework.data.annotation.PersistenceCreator
 import org.springframework.data.redis.core.RedisHash
-import java.net.URI
 import java.util.*
 
 @RedisHash("carts", timeToLive = 10 * 60L)

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/requests/repositories/PaymentInfo.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/requests/repositories/PaymentInfo.kt
@@ -5,7 +5,7 @@ import org.springframework.data.annotation.PersistenceCreator
 
 data class PaymentInfo @PersistenceCreator constructor(
     val rptId: RptId,
-    val description: String?,
+    val description: String,
     val amount: Int,
-    val companyName: String?
+    val companyName: String
 )

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/requests/services/CartService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/requests/services/CartService.kt
@@ -75,7 +75,7 @@ class CartService(
             withContext(Dispatchers.IO) {
                 cartInfoRepository.save(cart)
             }
-            
+
             CARTS_REDIRECT_URL_FORMAT.format(
                 checkoutUrl,
                 cart.cartId,
@@ -94,8 +94,8 @@ class CartService(
     /*
      * Fetch the cart with the input cart id
      */
-    fun getCart(cartId: String): CartRequestDto {
-        val cart = cartInfoRepository.findByIdOrNull(UUID.fromString(cartId)) ?: throw CartNotFoundException(cartId)
+    fun getCart(cartId: UUID): CartRequestDto {
+        val cart = cartInfoRepository.findByIdOrNull(cartId) ?: throw CartNotFoundException(cartId.toString())
 
         return CartRequestDto(
             paymentNotices = cart.payments.map {

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/requests/services/CartService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/requests/services/CartService.kt
@@ -39,13 +39,7 @@ class CartService(
          * The carts redirect url is composed as follow
          * {host}/carts/{cartId}
          */
-        //const val CARTS_REDIRECT_URL_FORMAT: String = "%s/carts/%s"
-        /**
-         * TODO change to the above constant when front-end application
-         * will correctly manage carts.
-         * For now return url is formatted as {host}/{fiscalCode}{noticeNumber} to redirect to checkout
-         */
-        const val CARTS_REDIRECT_URL_FORMAT: String = "%s/%s%s"
+        const val CARTS_REDIRECT_URL_FORMAT: String = "%s/carts/%s"
 
         const val MAX_ALLOWED_PAYMENT_NOTICES: Int = 1
     }
@@ -81,18 +75,12 @@ class CartService(
             withContext(Dispatchers.IO) {
                 cartInfoRepository.save(cart)
             }
-
-            /**
-             * TODO change to the above constant when front-end application
-             * will correctly manage carts.
-             * For now return url is formatted as {host}/{fiscalCode}{noticeNumber} to redirect to checkout
-             */
+            
             CARTS_REDIRECT_URL_FORMAT.format(
                 checkoutUrl,
-                //cart.cartId,
-                cart.payments[0].rptId.fiscalCode,
-                cart.payments[0].rptId.noticeId
-            )
+                cart.cartId,
+
+                )
         } else {
             logger.error("Too many payment notices, expected only one")
             throw RestApiException(

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/requests/services/CartService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/requests/services/CartService.kt
@@ -37,9 +37,9 @@ class CartService(
         /*
          * Carts redirect URL format.
          * The carts redirect url is composed as follow
-         * {host}/carts/{cartId}
+         * {host}/c/{cartId}
          */
-        const val CARTS_REDIRECT_URL_FORMAT: String = "%s/carts/%s"
+        const val CARTS_REDIRECT_URL_FORMAT: String = "%s/c/%s"
 
         const val MAX_ALLOWED_PAYMENT_NOTICES: Int = 1
     }

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/requests/services/CartService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/requests/services/CartService.kt
@@ -10,6 +10,7 @@ import it.pagopa.ecommerce.payment.requests.repositories.CartInfo
 import it.pagopa.ecommerce.payment.requests.repositories.CartInfoRepository
 import it.pagopa.ecommerce.payment.requests.repositories.PaymentInfo
 import it.pagopa.ecommerce.payment.requests.repositories.ReturnUrls
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.slf4j.Logger
@@ -25,7 +26,8 @@ import java.util.*
 @Service
 class CartService(
     @Value("\${checkout.url}") private val checkoutUrl: String,
-    @Autowired private val cartInfoRepository: CartInfoRepository
+    @Autowired private val cartInfoRepository: CartInfoRepository,
+    private val defaultDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
 
     /*
@@ -72,7 +74,7 @@ class CartService(
 
             logger.info("Saving cart ${cart.cartId} for payments $paymentInfos")
 
-            withContext(Dispatchers.IO) {
+            withContext(defaultDispatcher) {
                 cartInfoRepository.save(cart)
             }
 

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/requests/services/PaymentRequestsService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/requests/services/PaymentRequestsService.kt
@@ -8,6 +8,7 @@ import it.pagopa.ecommerce.generated.transactions.model.VerifyPaymentNoticeReq
 import it.pagopa.ecommerce.payment.requests.client.NodeForPspClient
 import it.pagopa.ecommerce.payment.requests.client.NodoPerPspClient
 import it.pagopa.ecommerce.payment.requests.domain.RptId
+import it.pagopa.ecommerce.payment.requests.exceptions.InvalidRptException
 import it.pagopa.ecommerce.payment.requests.exceptions.NodoErrorException
 import it.pagopa.ecommerce.payment.requests.repositories.PaymentRequestInfo
 import it.pagopa.ecommerce.payment.requests.repositories.PaymentRequestInfoRepository
@@ -51,7 +52,12 @@ class PaymentRequestsService(
     }
 
     suspend fun getPaymentRequestInfo(rptId: String): PaymentRequestsGetResponseDto {
-        val rptIdRecord = RptId(rptId)
+        val rptIdRecord: RptId;
+        try {
+            rptIdRecord = RptId(rptId)
+        } catch (e: IllegalArgumentException) {
+            throw InvalidRptException(rptId)
+        }
         val paymentContextCode = UUID.randomUUID().toString().replace("-", "")
         val paymentInfo = getPaymentInfoFromCache(rptIdRecord)
             .switchIfEmpty(

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,5 @@ nodo.connectionTimeout=${NODO_CONNECTION_TIMEOUT}
 nodo.connection.string=${NODO_CONNECTION_STRING}
 #fields to be obfuscated in case of bean validation failure
 fields_to_obscure={'emailNotice'}
+#disable null values serialization
+spring.jackson.default-property-inclusion=NON_NULL

--- a/src/test/kotlin/it/pagopa/ecommerce/payment/requests/controllers/CartsControllerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/payment/requests/controllers/CartsControllerTests.kt
@@ -135,7 +135,9 @@ class CartsControllerTests {
                 PaymentNoticeDto(
                     noticeNumber = "",
                     fiscalCode = "",
-                    amount = 10000
+                    amount = 10000,
+                    companyName = "companyName",
+                    description = "description"
                 )
             ),
             returnUrls = CartRequestReturnUrlsDto(

--- a/src/test/kotlin/it/pagopa/ecommerce/payment/requests/controllers/CartsControllerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/payment/requests/controllers/CartsControllerTests.kt
@@ -1,5 +1,6 @@
 package it.pagopa.ecommerce.payment.requests.controllers
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.ObjectMapper
 import it.pagopa.ecommerce.generated.payment.requests.server.model.CartRequestDto
 import it.pagopa.ecommerce.generated.payment.requests.server.model.CartRequestReturnUrlsDto
@@ -59,6 +60,7 @@ class CartsControllerTests {
     @Test
     fun `post cart KO with multiple payment notices`() = runTest {
         val objectMapper = ObjectMapper()
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
         val request = CartRequests.withMultiplePaymentNotice()
         given(cartService.processCart(request)).willThrow(
             RestApiException(
@@ -85,6 +87,7 @@ class CartsControllerTests {
     @Test
     fun `invalid request ko`() = runTest {
         val objectMapper = ObjectMapper()
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
         val request = CartRequests.invalidRequest()
         val errorResponse = ProblemJsonDto(
             status = 400,
@@ -105,6 +108,7 @@ class CartsControllerTests {
     @Test
     fun `controller throw generic exception`() = runTest {
         val objectMapper = ObjectMapper()
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
         val request = CartRequests.withOnePaymentNotice()
         val errorResponse = ProblemJsonDto(
             title = "Error processing the request",
@@ -125,6 +129,7 @@ class CartsControllerTests {
     fun `get cart by id`() {
         val cartId = UUID.randomUUID()
         val objectMapper = ObjectMapper()
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
         val response = CartRequestDto(
             paymentNotices = listOf(
                 PaymentNoticeDto(

--- a/src/test/kotlin/it/pagopa/ecommerce/payment/requests/controllers/CartsControllerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/payment/requests/controllers/CartsControllerTests.kt
@@ -123,7 +123,7 @@ class CartsControllerTests {
 
     @Test
     fun `get cart by id`() {
-        val cartId = "1234"
+        val cartId = UUID.randomUUID()
         val objectMapper = ObjectMapper()
         val response = CartRequestDto(
             paymentNotices = listOf(
@@ -151,8 +151,8 @@ class CartsControllerTests {
 
     @Test
     fun `get cart by id with non-existing cart returns 404`() {
-        val cartId = UUID.randomUUID().toString()
-        val exception = CartNotFoundException(cartId)
+        val cartId = UUID.randomUUID()
+        val exception = CartNotFoundException(cartId.toString())
         val expected = ProblemJsonDto(
             title = "Cart not found",
             detail = exception.message ?: "",

--- a/src/test/kotlin/it/pagopa/ecommerce/payment/requests/controllers/PaymentRequestsControllerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/payment/requests/controllers/PaymentRequestsControllerTests.kt
@@ -4,6 +4,7 @@ package it.pagopa.ecommerce.payment.requests.controllers
 import com.fasterxml.jackson.databind.ObjectMapper
 import it.pagopa.ecommerce.generated.nodoperpsp.model.FaultBean
 import it.pagopa.ecommerce.generated.payment.requests.server.model.*
+import it.pagopa.ecommerce.payment.requests.exceptions.InvalidRptException
 import it.pagopa.ecommerce.payment.requests.exceptions.NodoErrorException
 import it.pagopa.ecommerce.payment.requests.services.PaymentRequestsService
 import it.pagopa.ecommerce.payment.requests.tests.utils.PaymentRequests
@@ -71,6 +72,20 @@ class PaymentRequestsControllerTests {
             .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
             .expectBody(ProblemJsonDto::class.java).value {
                 assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), it.status)
+            }
+    }
+
+    @Test
+    fun `should return bad request response`() = runTest {
+        val rptId = "invalidRPT"
+        given(paymentRequestsService.getPaymentRequestInfo(rptId)).willThrow(InvalidRptException(rptId))
+        val parameters = mapOf("rpt_id" to rptId)
+        webClient.get()
+            .uri("/payment-requests/{rpt_id}", parameters)
+            .exchange()
+            .expectStatus().isEqualTo(HttpStatus.BAD_REQUEST)
+            .expectBody(ProblemJsonDto::class.java).value {
+                assertEquals(HttpStatus.BAD_REQUEST.value(), it.status)
             }
     }
 

--- a/src/test/kotlin/it/pagopa/ecommerce/payment/requests/services/CartsServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/payment/requests/services/CartsServiceTests.kt
@@ -36,17 +36,8 @@ class CartsServiceTests {
             uuidMock.`when`<UUID>(UUID::randomUUID).thenReturn(cartId)
 
             val request = CartRequests.withOnePaymentNotice()
-
-            /**
-             * TODO change this test when enable redirect to cart
-             * decommenting the below line
-             */
-            //val locationUrl = "${TEST_CHECKOUT_URL}/carts/${cartId}"
-            val locationUrl =
-                "${TEST_CHECKOUT_URL}/${request.paymentNotices[0].fiscalCode}${request.paymentNotices[0].noticeNumber}"
-
+            val locationUrl = "${TEST_CHECKOUT_URL}/carts/${cartId}"
             assertEquals(locationUrl, cartService.processCart(request))
-
             verify(cartInfoRepository, times(1)).save(any())
         }
     }

--- a/src/test/kotlin/it/pagopa/ecommerce/payment/requests/services/CartsServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/payment/requests/services/CartsServiceTests.kt
@@ -83,7 +83,7 @@ class CartsServiceTests {
                 Optional.of(cartInfo)
             })
 
-            assertEquals(request, cartService.getCart(cartId.toString()))
+            assertEquals(request, cartService.getCart(cartId))
         }
     }
 
@@ -94,7 +94,7 @@ class CartsServiceTests {
         given(cartInfoRepository.findById(cartId)).willReturn(Optional.empty())
 
         assertThrows<CartNotFoundException> {
-            cartService.getCart(cartId.toString())
+            cartService.getCart(cartId)
         }
     }
 }

--- a/src/test/kotlin/it/pagopa/ecommerce/payment/requests/services/CartsServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/payment/requests/services/CartsServiceTests.kt
@@ -36,7 +36,7 @@ class CartsServiceTests {
             uuidMock.`when`<UUID>(UUID::randomUUID).thenReturn(cartId)
 
             val request = CartRequests.withOnePaymentNotice()
-            val locationUrl = "${TEST_CHECKOUT_URL}/carts/${cartId}"
+            val locationUrl = "${TEST_CHECKOUT_URL}/c/${cartId}"
             assertEquals(locationUrl, cartService.processCart(request))
             verify(cartInfoRepository, times(1)).save(any())
         }

--- a/src/test/kotlin/it/pagopa/ecommerce/payment/requests/services/PaymentRequestsServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/payment/requests/services/PaymentRequestsServiceTests.kt
@@ -7,6 +7,7 @@ import it.pagopa.ecommerce.generated.transactions.model.*
 import it.pagopa.ecommerce.payment.requests.client.NodeForPspClient
 import it.pagopa.ecommerce.payment.requests.client.NodoPerPspClient
 import it.pagopa.ecommerce.payment.requests.domain.RptId
+import it.pagopa.ecommerce.payment.requests.exceptions.InvalidRptException
 import it.pagopa.ecommerce.payment.requests.exceptions.NodoErrorException
 import it.pagopa.ecommerce.payment.requests.repositories.PaymentRequestInfo
 import it.pagopa.ecommerce.payment.requests.repositories.PaymentRequestInfoRepository
@@ -14,8 +15,7 @@ import it.pagopa.ecommerce.payment.requests.utils.NodoOperations
 import it.pagopa.ecommerce.payment.requests.utils.NodoUtils
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -24,6 +24,7 @@ import org.mockito.BDDMockito.given
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.springframework.http.HttpStatus
 import reactor.core.publisher.Mono
 import java.math.BigDecimal
 import java.text.DateFormat
@@ -422,6 +423,16 @@ class PaymentRequestsServiceTests {
             paymentRequestsService.getPaymentRequestInfo(rptIdAsString)
         }
         assertEquals("PAA_PAGAMENTO_DUPLICATO", exception.faultCode)
+    }
+
+    @Test
+    fun `should return invalid request for invalid rpt id`() = runTest {
+        val rptIdAsString = "invalid rpt id"
+        val exception = assertThrows<InvalidRptException> {
+            paymentRequestsService.getPaymentRequestInfo(rptIdAsString)
+        }
+        assertEquals(HttpStatus.BAD_REQUEST, exception.toRestException().httpStatus)
+        assertTrue(exception.toRestException().description.contains(rptIdAsString))
     }
 
 

--- a/src/test/kotlin/it/pagopa/ecommerce/payment/requests/tests/utils/CartRequests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/payment/requests/tests/utils/CartRequests.kt
@@ -13,7 +13,9 @@ object CartRequests {
                 PaymentNoticeDto(
                     noticeNumber = "302000100440009424",
                     fiscalCode = "77777777777",
-                    amount = 10000
+                    amount = 10000,
+                    companyName = "companyName",
+                    description = "description"
                 )
             ),
             returnUrls = CartRequestReturnUrlsDto(
@@ -31,12 +33,16 @@ object CartRequests {
                 PaymentNoticeDto(
                     noticeNumber = "302000100440009420",
                     fiscalCode = "77777777777",
-                    amount = 10000
+                    amount = 10000,
+                    companyName = "companyName",
+                    description = "description"
                 ),
                 PaymentNoticeDto(
                     noticeNumber = "302000100440009421",
                     fiscalCode = "77777777777",
-                    amount = 10000
+                    amount = 10000,
+                    companyName = "companyName",
+                    description = "description"
                 )
             ),
             returnUrls = CartRequestReturnUrlsDto(
@@ -53,7 +59,9 @@ object CartRequests {
                 PaymentNoticeDto(
                     noticeNumber = "1",
                     fiscalCode = "1",
-                    amount = 10000
+                    amount = 10000,
+                    companyName = "companyName",
+                    description = "description"
                 )
             ),
             returnUrls = CartRequestReturnUrlsDto(

--- a/tests/api-tests/payment-requests.api.tests.json
+++ b/tests/api-tests/payment-requests.api.tests.json
@@ -1,6 +1,6 @@
 {
   "info": {
-    "_postman_id": "88105536-9963-494e-bb79-a83900d58d1c",
+    "_postman_id": "a7808a10-c95a-492f-b6d5-60de7246df58",
     "name": "PagoPA ecommerce payment requests test collection",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "_exporter_id": "23963988"
@@ -34,7 +34,7 @@
         ],
         "body": {
           "mode": "raw",
-          "raw": "{\n    \"paymentNotices\": [\n        {\n            \"noticeNumber\": \"302000100440009424\",\n            \"fiscalCode\": \"77777777777\",\n            \"amount\": 10000,\n            \"companyName\": null,\n            \"description\": null\n        }\n    ],\n    \"returnUrls\": {\n        \"returnOkUrl\": \"https://returnOkUrl\",\n        \"returnCancelUrl\": \"https://returnCancelUrl\",\n        \"returnErrorUrl\": \"https://returnErrorUrl\"\n    },\n    \"emailNotice\": \"test@test.it\"\n}",
+          "raw": "{\n    \"paymentNotices\": [\n        {\n            \"noticeNumber\": \"302000100440009424\",\n            \"fiscalCode\": \"77777777777\",\n            \"amount\": 10000,\n            \"companyName\": \"companyName\",\n            \"description\": \"description\"\n        }\n    ],\n    \"returnUrls\": {\n        \"returnOkUrl\": \"https://returnOkUrl\",\n        \"returnCancelUrl\": \"https://returnCancelUrl\",\n        \"returnErrorUrl\": \"https://returnErrorUrl\"\n    },\n    \"emailNotice\": \"test@test.it\"\n}",
           "options": {
             "raw": {
               "language": "json"
@@ -42,14 +42,14 @@
           }
         },
         "url": {
-          "raw": "https://{{host}}/checkout/ecommerce/v1/carts",
+          "raw": "https://{{host}}/checkout/ec/v1/carts",
           "protocol": "https",
           "host": [
             "{{host}}"
           ],
           "path": [
             "checkout",
-            "ecommerce",
+            "ec",
             "v1",
             "carts"
           ]
@@ -138,14 +138,14 @@
           }
         },
         "url": {
-          "raw": "https://{{host}}/checkout/ecommerce/v1/carts",
+          "raw": "https://{{host}}/checkout/ec/v1/carts",
           "protocol": "https",
           "host": [
             "{{host}}"
           ],
           "path": [
             "checkout",
-            "ecommerce",
+            "ec",
             "v1",
             "carts"
           ]
@@ -189,14 +189,14 @@
           }
         },
         "url": {
-          "raw": "https://{{host}}/checkout/ecommerce/v1/carts",
+          "raw": "https://{{host}}/checkout/ec/v1/carts",
           "protocol": "https",
           "host": [
             "{{host}}"
           ],
           "path": [
             "checkout",
-            "ecommerce",
+            "ec",
             "v1",
             "carts"
           ]
@@ -235,14 +235,13 @@
         "method": "GET",
         "header": [
           {
-            "key": "",
+            "key": "deployment",
             "type": "text",
-            "value": "",
-            "disabled": true
+            "value": "blue"
           }
         ],
         "url": {
-          "raw": "https://{{host}}/checkout/ecommerce/v1/payment-requests/{{RPTID_NM3}}",
+          "raw": "https://{{host}}/checkout/ecommerce/v1/payment-requests/{{RPTID_NM3}}?recaptchaResponse=test",
           "protocol": "https",
           "host": [
             "{{host}}"
@@ -253,6 +252,12 @@
             "v1",
             "payment-requests",
             "{{RPTID_NM3}}"
+          ],
+          "query": [
+            {
+              "key": "recaptchaResponse",
+              "value": "test"
+            }
           ]
         },
         "description": "1. recupero info relativi alla request payment con verificaRPT se non presente in cache dato rptId\n2. cache info su redis dato rptId"


### PR DESCRIPTION
This pull depends on pagopa/pagopa-checkout-fe#137
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Changed the POST carts location URL: 
{checkout.url}/{rptId} -> {checkout.url}/c/{cartId}
with the cartId equal to the POST created cart unique id.

- Changed the cartId path parameter format to UUID.
- Mapped payment-request return code in case of invalid RPT ID received to 400 (before was 500)
<!--- Describe your changes in detail -->

#### Motivation and Context
Those changes are required in order to make available the EC created cart to the checkout FE.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
unit test and local test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.