### PR TITLE
feat: add Rest controllers warmup requests

### DIFF
--- a/.devops/code-review-pipelines.yml
+++ b/.devops/code-review-pipelines.yml
@@ -25,7 +25,7 @@ steps:
       extraProperties: |
         sonar.projectKey=$(SONARCLOUD_PROJECT_KEY)
         sonar.projectName=$(SONARCLOUD_PROJECT_NAME)
-        sonar.coverage.exclusions=**/config/*,**/*Mock*,**/model/*,**/it/pagopa/generated/**/*,**/it/pagopa/ecommerce/payment/requests/utils/soap/**/*
+        sonar.coverage.exclusions=**/config/*,**/*Mock*,**/model/*,**/it/pagopa/generated/**/*,**/it/pagopa/ecommerce/payment/requests/utils/soap/**/*,**/it/pagopa/ecommerce/payment/requests/warmup/**/*
         sonar.coverage.jacoco.xmlReportPaths=./target/site/jacoco/jacoco.xml
         sonar.junit.reportPaths=target/surefire-reports/
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,14 @@ services:
     networks:
       - pagopa-ecommerce-net
     env_file: .env
+    deploy:
+      resources:
+        limits:
+          cpus: '0.300'
+          memory: 512M
+        reservations:
+          cpus: '0.300'
+          memory: 512M
   redis:
     container_name: pagopa-ecommerce-redis
     image: redis

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -30,9 +30,9 @@ microservice-chart:
     pathType: "ImplementationSpecific"
   serviceAccount:
     create: false
-    annotations: {}
+    annotations: { }
     name: ""
-  podAnnotations: {}
+  podAnnotations: { }
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
@@ -43,11 +43,11 @@ microservice-chart:
     port: 8080
   resources:
     requests:
-      memory: "384Mi"
-      cpu: "200m"
+      memory: "512Mi"
+      cpu: "300m"
     limits:
-      memory: "384Mi"
-      cpu: "200m"
+      memory: "512Mi"
+      cpu: "300m"
   autoscaling:
     minReplica: 1
     maxReplica: 2
@@ -83,6 +83,6 @@ microservice-chart:
   keyvault:
     name: "pagopa-d-ecommerce-kv"
     tenantId: "7788edaf-0346-4068-9d79-c868aed15b3d"
-  nodeSelector: {}
-  tolerations: []
-  affinity: {}
+  nodeSelector: { }
+  tolerations: [ ]
+  affinity: { }

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <sonar.coverage.exclusions>
             **/it/pagopa/generated/**/*,
             **/it/pagopa/ecommerce/payment/requests/utils/soap/**/*
+            **/it/pagopa/ecommerce/payment/requests/warmup/**/*
         </sonar.coverage.exclusions>
     </properties>
     <dependencies>
@@ -342,6 +343,7 @@
                     <excludes>
                         <exclude>it/pagopa/ecommerce/generated/**</exclude>
                         <exclude>it/pagopa/ecommerce/payment/requests/utils/soap/**</exclude>
+                        <exclude>it/pagopa/ecommerce/payment/requests/warmup/**</exclude>
                     </excludes>
                 </configuration>
                 <executions>

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/requests/client/NodeForPspClient.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/requests/client/NodeForPspClient.kt
@@ -36,7 +36,7 @@ class NodeForPspClient(
                     )
                 }
             }.bodyToMono(VerifyPaymentNoticeRes::class.java)
-            .doOnSuccess() {
+            .doOnSuccess {
                 logger.debug(
                     "Payment activated with payment token [{}]", request.value.qrCode.noticeNumber
                 )

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/requests/client/NodoPerPspClient.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/requests/client/NodoPerPspClient.kt
@@ -41,7 +41,7 @@ class NodoPerPspClient(
                     )
                 }
             }.bodyToMono(NodoVerificaRPTRisposta::class.java)
-            .doOnSuccess() { logger.debug("Payment info for {}", request.value.codiceIdRPT) }
+            .doOnSuccess { logger.debug("Payment info for {}", request.value.codiceIdRPT) }
             .doOnError(ResponseStatusException::class.java) { logger.error("ResponseStatus Error: ", it) }
             .doOnError(Exception::class.java) { logger.error("Generic exception: ", it) }
 

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/requests/controllers/CartsController.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/requests/controllers/CartsController.kt
@@ -4,17 +4,21 @@ import it.pagopa.ecommerce.generated.payment.requests.server.api.CartsApi
 import it.pagopa.ecommerce.generated.payment.requests.server.model.CartRequestDto
 import it.pagopa.ecommerce.payment.requests.services.CartService
 import it.pagopa.ecommerce.payment.requests.warmup.annotations.WarmupFunction
+import it.pagopa.ecommerce.payment.requests.warmup.exceptions.WarmUpException
 import it.pagopa.ecommerce.payment.requests.warmup.utils.WarmupRequests
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
-import org.springframework.web.client.RestTemplate
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
 import java.net.URI
+import java.time.Duration
+import java.time.temporal.ChronoUnit
 
 @RestController
 class CartsController(
-    private val restTemplate: RestTemplate = RestTemplate()
+    private val webClient: WebClient = WebClient.create()
 ) : CartsApi {
     @Autowired
     private lateinit var cartService: CartService
@@ -39,6 +43,10 @@ class CartsController(
      */
     @WarmupFunction
     fun warmupPostCarts() {
-        restTemplate.postForLocation("http://localhost:8080/carts", WarmupRequests.postCartsReq())
+        webClient.post().uri("http://localhost:8080/carts")
+            .body(Mono.just(WarmupRequests.postCartsReq()), CartRequestDto::class.java)
+            .retrieve()
+            .onStatus(HttpStatus::isError) { Mono.error(WarmUpException("CartsController", "warmupPostCarts")) }
+            .toBodilessEntity().block(Duration.of(10, ChronoUnit.SECONDS))
     }
 }

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/requests/controllers/CartsController.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/requests/controllers/CartsController.kt
@@ -3,18 +3,21 @@ package it.pagopa.ecommerce.payment.requests.controllers
 import it.pagopa.ecommerce.generated.payment.requests.server.api.CartsApi
 import it.pagopa.ecommerce.generated.payment.requests.server.model.CartRequestDto
 import it.pagopa.ecommerce.payment.requests.services.CartService
+import it.pagopa.ecommerce.payment.requests.warmup.annotations.WarmupFunction
+import it.pagopa.ecommerce.payment.requests.warmup.utils.WarmupRequests
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.client.RestTemplate
 import java.net.URI
 
 @RestController
 class CartsController(
+    private val restTemplate: RestTemplate = RestTemplate()
 ) : CartsApi {
-
     @Autowired
-    lateinit var cartService: CartService
+    private lateinit var cartService: CartService
 
     override suspend fun postCarts(cartRequestDto: CartRequestDto): ResponseEntity<Unit> {
         return ResponseEntity
@@ -29,5 +32,13 @@ class CartsController(
         return ResponseEntity.ok(
             cartService.getCart(idCart)
         )
+    }
+
+    /**
+     * Controller warm up function, used to send a POST carts request
+     */
+    @WarmupFunction
+    fun warmupPostCarts() {
+        restTemplate.postForLocation("http://localhost:8080/carts", WarmupRequests.postCartsReq())
     }
 }

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/requests/controllers/PaymentRequestsController.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/requests/controllers/PaymentRequestsController.kt
@@ -30,7 +30,7 @@ class PaymentRequestsController(
     }
 
     /**
-     * Controller warm up function, used to send a POST carts request
+     * Controller warm up function, used to send a GET payment-request
      */
     @WarmupFunction
     fun warmupGetPaymentRequest() {

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/requests/controllers/PaymentRequestsController.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/requests/controllers/PaymentRequestsController.kt
@@ -3,19 +3,36 @@ package it.pagopa.ecommerce.payment.requests.controllers
 import it.pagopa.ecommerce.generated.payment.requests.server.api.PaymentRequestsApi
 import it.pagopa.ecommerce.generated.payment.requests.server.model.PaymentRequestsGetResponseDto
 import it.pagopa.ecommerce.payment.requests.services.PaymentRequestsService
+import it.pagopa.ecommerce.payment.requests.warmup.annotations.WarmupFunction
+import it.pagopa.ecommerce.payment.requests.warmup.utils.WarmupRequests
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.client.RestTemplate
 
 @RestController
 class PaymentRequestsController(
-
+    private val restTemplate: RestTemplate = RestTemplate()
 ) : PaymentRequestsApi {
+
     @Autowired
     private lateinit var paymentRequestsService: PaymentRequestsService
+
     override suspend fun getPaymentRequestInfo(rptId: String): ResponseEntity<PaymentRequestsGetResponseDto> {
         return ResponseEntity.ok(
             paymentRequestsService.getPaymentRequestInfo(rptId)
+        )
+    }
+
+    /**
+     * Controller warm up function, used to send a POST carts request
+     */
+    @WarmupFunction
+    fun warmupGetPaymentRequest() {
+        restTemplate.getForEntity(
+            "http://localhost:8080/payment-requests/{rpt_id}",
+            PaymentRequestsGetResponseDto::class.java,
+            mapOf<String, String>("rpt_id" to WarmupRequests.getPaymentRequest())
         )
     }
 }

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/requests/controllers/PaymentRequestsController.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/requests/controllers/PaymentRequestsController.kt
@@ -4,15 +4,20 @@ import it.pagopa.ecommerce.generated.payment.requests.server.api.PaymentRequests
 import it.pagopa.ecommerce.generated.payment.requests.server.model.PaymentRequestsGetResponseDto
 import it.pagopa.ecommerce.payment.requests.services.PaymentRequestsService
 import it.pagopa.ecommerce.payment.requests.warmup.annotations.WarmupFunction
+import it.pagopa.ecommerce.payment.requests.warmup.exceptions.WarmUpException
 import it.pagopa.ecommerce.payment.requests.warmup.utils.WarmupRequests
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
-import org.springframework.web.client.RestTemplate
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
+import java.time.Duration
+import java.time.temporal.ChronoUnit
 
 @RestController
 class PaymentRequestsController(
-    private val restTemplate: RestTemplate = RestTemplate()
+    private val webClient: WebClient = WebClient.create()
 ) : PaymentRequestsApi {
 
     @Autowired
@@ -29,10 +34,18 @@ class PaymentRequestsController(
      */
     @WarmupFunction
     fun warmupGetPaymentRequest() {
-        restTemplate.getForEntity(
+        webClient.get().uri(
             "http://localhost:8080/payment-requests/{rpt_id}",
-            PaymentRequestsGetResponseDto::class.java,
-            mapOf<String, String>("rpt_id" to WarmupRequests.getPaymentRequest())
-        )
+            mapOf("rpt_id" to WarmupRequests.getPaymentRequest())
+        ).retrieve()
+            .onStatus(HttpStatus::isError) {
+                Mono.error(
+                    WarmUpException(
+                        "PaymentRequestsController",
+                        "warmupGetPaymentRequest"
+                    )
+                )
+            }
+            .toBodilessEntity().block(Duration.of(10, ChronoUnit.SECONDS))
     }
 }

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/requests/warmup/ControllersWarmup.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/requests/warmup/ControllersWarmup.kt
@@ -1,0 +1,60 @@
+package it.pagopa.ecommerce.payment.requests.warmup
+
+import it.pagopa.ecommerce.payment.requests.warmup.annotations.WarmupFunction
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.getBeansWithAnnotation
+import org.springframework.context.ApplicationListener
+import org.springframework.context.event.ContextRefreshedEvent
+import org.springframework.stereotype.Component
+import org.springframework.util.ClassUtils
+import org.springframework.web.bind.annotation.RestController
+import kotlin.reflect.full.declaredMemberFunctions
+import kotlin.reflect.full.hasAnnotation
+import kotlin.system.measureTimeMillis
+
+@Component
+class ControllersWarmup : ApplicationListener<ContextRefreshedEvent> {
+
+    private val logger = LoggerFactory.getLogger(this.javaClass)
+    override fun onApplicationEvent(event: ContextRefreshedEvent) {
+        val restControllers =
+            event.applicationContext.getBeansWithAnnotation<RestController>()
+                .map { it.value }
+        logger.info("Found controllers: [{}]", restControllers.size)
+        restControllers.forEach(this::warmUpController)
+    }
+
+    private fun warmUpController(controllerToWarmUpInstance: Any) {
+        var warmUpMethods = 0
+        val controllerToWarmUpKClass = ClassUtils.getUserClass(controllerToWarmUpInstance).kotlin
+        val elapsedTime = measureTimeMillis {
+            runCatching {
+                println(controllerToWarmUpKClass.declaredMemberFunctions.filter { it.hasAnnotation<WarmupFunction>() })
+                controllerToWarmUpKClass.declaredMemberFunctions.filter { it.hasAnnotation<WarmupFunction>() }
+                    .forEach {
+                        warmUpMethods++
+                        val result: Result<*>
+                        val intertime = measureTimeMillis {
+                            result = runCatching {
+                                logger.info("Invoking function: [{}]", it.toString())
+                                it.call(controllerToWarmUpInstance)
+                            }
+                        }
+                        logger.info(
+                            "Warmup function: [{}] -> elapsed time: [{}]. Is ok: [{}] ",
+                            it.toString(),
+                            intertime,
+                            result
+                        )
+                    }
+            }.getOrElse { logger.error("Exception performing controller warm up ", it) }
+        }
+        logger.info(
+            "Controller: [{}] warm-up executed functions: [{}], elapsed time: [{}] ms",
+            controllerToWarmUpKClass,
+            warmUpMethods,
+            elapsedTime
+        )
+    }
+}
+

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/requests/warmup/annotations/WarmupFunction.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/requests/warmup/annotations/WarmupFunction.kt
@@ -1,0 +1,11 @@
+package it.pagopa.ecommerce.payment.requests.warmup.annotations
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+/**
+ * Annotation used to annotate a controller function to be called during module warm-up phase.
+ * Warm-up function can be used to send request to a RestController in order to initialize all it's resource
+ * before the module being ready to serve requests
+ */
+annotation class WarmupFunction {
+}

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/requests/warmup/exceptions/WarmUpException.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/requests/warmup/exceptions/WarmUpException.kt
@@ -1,0 +1,5 @@
+package it.pagopa.ecommerce.payment.requests.warmup.exceptions
+
+class WarmUpException(controllerName: String, functionName: String) :
+    RuntimeException("Exception performing warm-up function $controllerName.$functionName") {
+}

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/requests/warmup/utils/WarmupRequests.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/requests/warmup/utils/WarmupRequests.kt
@@ -1,0 +1,29 @@
+package it.pagopa.ecommerce.payment.requests.warmup.utils
+
+import it.pagopa.ecommerce.generated.payment.requests.server.model.CartRequestDto
+import it.pagopa.ecommerce.generated.payment.requests.server.model.CartRequestReturnUrlsDto
+import it.pagopa.ecommerce.generated.payment.requests.server.model.PaymentNoticeDto
+import java.net.URI
+
+object WarmupRequests {
+
+    fun postCartsReq() = CartRequestDto(
+        paymentNotices = listOf(
+            PaymentNoticeDto(
+                noticeNumber = "000000000000000000",
+                fiscalCode = "00000000000",
+                amount = 1,
+                companyName = "test-warm-up-req",
+                description = "test-warm-up-req"
+            )
+        ),
+        returnUrls = CartRequestReturnUrlsDto(
+            returnOkUrl = URI("www.warmup-req-ok.it"),
+            returnCancelUrl = URI("www.warmup-req-cancel.it"),
+            returnErrorUrl = URI("www.warmup-req-error.it"),
+        ),
+        emailNotice = "my_email@mail.it"
+    )
+
+    fun getPaymentRequest(): String = "00000000000000000000000000000"
+}

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/requests/warmup/utils/WarmupRequests.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/requests/warmup/utils/WarmupRequests.kt
@@ -11,7 +11,7 @@ object WarmupRequests {
         paymentNotices = listOf(
             PaymentNoticeDto(
                 noticeNumber = "000000000000000000",
-                fiscalCode = "00000000000",
+                fiscalCode = "77777777777",
                 amount = 1,
                 companyName = "test-warm-up-req",
                 description = "test-warm-up-req"
@@ -25,5 +25,5 @@ object WarmupRequests {
         emailNotice = "my_email@mail.it"
     )
 
-    fun getPaymentRequest(): String = "00000000000000000000000000000"
+    fun getPaymentRequest(): String = "77777777777000000000000000000"
 }

--- a/src/test/kotlin/it/pagopa/ecommerce/payment/requests/controllers/CartsControllerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/payment/requests/controllers/CartsControllerTests.kt
@@ -24,6 +24,7 @@ import org.springframework.http.MediaType
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
+import org.springframework.web.client.RestTemplate
 import java.net.URI
 import java.util.*
 
@@ -38,6 +39,7 @@ class CartsControllerTests {
 
     @MockBean
     lateinit var cartService: CartService
+
 
     @InjectMocks
     val cartsController: CartsController = CartsController()
@@ -168,5 +170,13 @@ class CartsControllerTests {
             .expectStatus().isNotFound
             .expectBody<ProblemJsonDto>()
             .isEqualTo(expected)
+    }
+
+    @Test
+    fun `warm up controller`() {
+        val restTemplate = mock(RestTemplate::class.java)
+        given(restTemplate.postForLocation(any<String>(), any())).willReturn(URI.create("http://redirect"))
+        CartsController(restTemplate).warmupPostCarts()
+        verify(restTemplate, times(1)).postForLocation(any<String>(), any())
     }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add logic to perform Rest controllers warm-up by performing a localhost request after the module has been deployed
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Rest controllers are lazily initialized causing the first request to be served slowly compared to the next requests.
This behaviour is caused by the lazy initialization overhead for instantiating all necessary resources (classes etc).
#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Test performed locally verifying that the first request is served faster than the warm-up one
#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.