### PR TITLE
fix: handle verify payment response KO

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/payment/requests/exceptions/NodoErrorException.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/requests/exceptions/NodoErrorException.kt
@@ -1,28 +1,30 @@
 package it.pagopa.ecommerce.payment.requests.exceptions
 
 import it.pagopa.ecommerce.generated.nodoperpsp.model.FaultBean
+import it.pagopa.ecommerce.generated.transactions.model.CtFaultBean
 import java.util.regex.Pattern
 
 class NodoErrorException(val faultCode: String) :
     RuntimeException("Exception communication with nodo. Fault code: [${faultCode}]") {
 
-    constructor(faultBean: FaultBean) : this(getFaultCodeFromBean(faultBean))
-
+    constructor(faultBean: FaultBean?) : this(getFaultCodeFromBean(faultBean?.faultCode, faultBean?.description))
+    constructor(faultBean: CtFaultBean?) : this(getFaultCodeFromBean(faultBean?.faultCode, faultBean?.description))
 
     companion object {
         var faultCodePattern: Pattern = Pattern.compile("(PAA|PPT)_\\S+")
-        fun getFaultCodeFromBean(faultBean: FaultBean): String {
-            val description: String? = faultBean.description
-            return if (description != null) {
-                val matcher = faultCodePattern.matcher(description)
-                if (matcher.find()) {
-                    matcher.group()
+        fun getFaultCodeFromBean(faultCode: String?, description: String?): String {
+            val extractedFaultCode =
+                if (description != null) {
+                    val matcher = faultCodePattern.matcher(description)
+                    if (matcher.find()) {
+                        matcher.group()
+                    } else {
+                        faultCode
+                    }
                 } else {
-                    faultBean.faultCode
+                    faultCode
                 }
-            } else {
-                faultBean.faultCode
-            }
+            return extractedFaultCode ?: "Unreadable fault code"
         }
     }
 }

--- a/src/test/kotlin/it/pagopa/ecommerce/payment/requests/controllers/PaymentRequestsControllerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/payment/requests/controllers/PaymentRequestsControllerTests.kt
@@ -47,9 +47,6 @@ class PaymentRequestsControllerTests {
     lateinit var paymentRequestsService: PaymentRequestsService
 
     @Mock
-    private lateinit var requestBodyUriSpec: WebClient.RequestBodyUriSpec
-
-    @Mock
     private lateinit var requestHeadersSpec: WebClient.RequestHeadersUriSpec<*>
 
     @Mock


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add logic to handle VerifyPaymentNoticeRes error responses
<!--- Describe your changes in detail -->

#### Motivation and Context
VerifyPaymentNoticeRes error was wrongly not checked before mapping received response to the caller.
This causes unhandled exception in case of error responses received from Nodo that were mapped to 500 internal server error.
Error codes received from Nodo are now mapped to the proper response code 
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Locally sending request to UAT Nodo for an already payed payment request checking that the returned response code is the expected ones
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.