### PR TITLE
CHK-1078 nullable for amount and delete isCart

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/payment/requests/domain/IdempotencyKey.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/requests/domain/IdempotencyKey.kt
@@ -4,21 +4,21 @@ import java.util.regex.Pattern
 import org.springframework.data.annotation.PersistenceCreator
 
 class IdempotencyKey {
-  val key: String
+  val rawValue: String
 
   constructor(pspFiscalCode: String, keyIdentifier: String) {
     validateComponents(pspFiscalCode, keyIdentifier)
-    key = pspFiscalCode + "_" + keyIdentifier
+    rawValue = pspFiscalCode + "_" + keyIdentifier
   }
 
   @PersistenceCreator
-  constructor(key: String) {
-    val matches = key.split("_".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+  constructor(rawValue: String) {
+    val matches = rawValue.split("_".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
     require(matches.size == 2) { "Key doesn't match format `\$pspFiscalCode_\$keyIdentifier`" }
     val pspFiscalCode = matches[0]
     val keyIdentifier = matches[1]
     validateComponents(pspFiscalCode, keyIdentifier)
-    this.key = key
+    this.rawValue = rawValue
   }
 
   companion object {
@@ -42,16 +42,16 @@ class IdempotencyKey {
 
     other as IdempotencyKey
 
-    if (key != other.key) return false
+    if (rawValue != other.rawValue) return false
 
     return true
   }
 
   override fun hashCode(): Int {
-    return key.hashCode()
+    return rawValue.hashCode()
   }
 
   override fun toString(): String {
-    return "IdempotencyKey(key='$key')"
+    return "IdempotencyKey(key='$rawValue')"
   }
 }

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/requests/repositories/PaymentRequestInfo.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/requests/repositories/PaymentRequestInfo.kt
@@ -14,9 +14,8 @@ constructor(
   val paFiscalCode: String?,
   val paName: String?,
   val description: String?,
-  val amount: Int,
+  val amount: Int?,
   val dueDate: String?,
   val paymentToken: String?,
   val idempotencyKey: IdempotencyKey?,
-  val isCart: Boolean
 )

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/requests/services/PaymentRequestsService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/requests/services/PaymentRequestsService.kt
@@ -62,7 +62,7 @@ class PaymentRequestsService(
             paName = paymentInfo.paName,
             dueDate = paymentInfo.dueDate,
             description = paymentInfo.description,
-            amount = paymentInfo.amount,
+            amount = paymentInfo.amount!!,
             paymentContextCode = paymentContextCode)
         }
         .doOnNext { logger.info("PaymentRequestInfo retrieved for {}", rptId) }
@@ -74,7 +74,10 @@ class PaymentRequestsService(
       paymentRequestInfoRepository.findById(rptId)
     logger.info(
       "PaymentRequestInfo cache hit for {}: {}", rptId, paymentRequestInfoOptional.isPresent)
-    return paymentRequestInfoOptional.map { Mono.just(it) }.orElseGet { Mono.empty() }
+    return paymentRequestInfoOptional
+      .filter { it.amount != null }
+      .map { Mono.just(it) }
+      .orElseGet { Mono.empty() }
   }
 
   fun getPaymentInfoFromNodo(rptId: RptId, paymentContextCode: String): Mono<PaymentRequestInfo> =
@@ -116,8 +119,7 @@ class PaymentRequestsService(
                     getDueDateString(
                       verifyPaymentNoticeResponse.paymentList.paymentOptionDescription[0].dueDate),
                   paymentToken = null,
-                  idempotencyKey = null,
-                  isCart = false))
+                  idempotencyKey = null))
             }
           }
       return@flatMap paymentRequestInfo

--- a/src/test/kotlin/it/pagopa/ecommerce/payment/requests/domain/IdempotencyKeyTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/payment/requests/domain/IdempotencyKeyTests.kt
@@ -31,7 +31,7 @@ class IdempotencyKeyTests {
   @Test
   fun `should return key`() {
     val idempotencyKey = IdempotencyKey(VALID_FISCAL_CODE, VALID_KEY_ID)
-    assertTrue(idempotencyKey.key == VALID_FISCAL_CODE + "_" + VALID_KEY_ID)
+    assertTrue(idempotencyKey.rawValue == VALID_FISCAL_CODE + "_" + VALID_KEY_ID)
   }
 
   @Test

--- a/src/test/kotlin/it/pagopa/ecommerce/payment/requests/services/PaymentRequestsServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/payment/requests/services/PaymentRequestsServiceTests.kt
@@ -62,8 +62,7 @@ class PaymentRequestsServiceTests {
     val description = "Payment request description"
     val amount = Integer.valueOf(1000)
     val paymentRequestInfo =
-      PaymentRequestInfo(
-        rptIdAsObject, paTaxCode, paName, description, amount, null, null, null, false)
+      PaymentRequestInfo(rptIdAsObject, paTaxCode, paName, description, amount, null, null, null)
     /** preconditions */
     given(paymentRequestsInfoRepository.findById(rptIdAsObject))
       .willReturn(Optional.of(paymentRequestInfo))


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- `amount` as nullable field of `PaymentRequestInfo`;
- `isCart` of  `PaymentRequestInfo` deleted;
- consider a valid `PaymentRequestInfo` only with amount not null;

#### Motivation and Context

The goal of this PR is to align `PaymentRequestInfo` according to https://github.com/pagopa/pagopa-ecommerce-transactions-service/pull/138

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.