### PR TITLE
feat: parametrize max carts payment notices

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,5 @@ NODO_READ_TIMEOUT=10000
 NODO_CONNECTION_TIMEOUT=10000
 
 NODO_CONNECTION_STRING="{\"idPSP\":\"idPsp\",\"idChannel\":\"idChannel\",\"idBrokerPSP\":\"idBrokerPsp\",\"password\":\"password\"}"
+
+CARTS_MAX_ALLOWED_PAYMENT_NOTICES=5

--- a/README.md
+++ b/README.md
@@ -7,19 +7,20 @@ with redirects to [_pagoPA – Checkout_](https://checkout.pagopa.it).
 
 ### Environment variables
 
-| Variable name           | Description                                                                 | type          | default |
-|-------------------------|-----------------------------------------------------------------------------|---------------|---------|
-| CHECKOUT_URL            | Redirection URL for Checkout carts                                          | url (string)  |         |
-| REDIS_HOST              | Host where the redis instance used to persist idempotency keys can be found | string        |         |
-| REDIS_PASSWORD          | Password used for connecting to Redis instance                              | string        |         |
-| REDIS_PORT              | Port used for connecting to Redis instance                                  | number        |         |
-| REDIS_SSL_ENABLED       | Whether SSL is enabled when connecting to Redis                             | boolean       |         |
-| NODO_HOSTNAME           | Nodo connection host name                                                   | string        |         |
-| NODO_PER_PSP_URI        | Nodo per PSP URI                                                            | string        |         |
-| NODE_FOR_PSP_URI        | Nodo for PSP URI                                                            | string        |         |
-| NODO_READ_TIMEOUT       | Http read timeout for all call made to Nodo                                 | number        |         |
-| NODO_CONNECTION_TIMEOUT | Http connection timeout for all call made to Nodo                           | number        |         |
-| NODO_CONNECTION_STRING  | Connection string containing information used to make Nodo calls            | json (string) |         |
+| Variable name                     | Description                                                                  | type          | default |
+|-----------------------------------|------------------------------------------------------------------------------|---------------|---------|
+| CHECKOUT_URL                      | Redirection URL for Checkout carts                                           | url (string)  |         |
+| REDIS_HOST                        | Host where the redis instance used to persist idempotency keys can be found  | string        |         |
+| REDIS_PASSWORD                    | Password used for connecting to Redis instance                               | string        |         |
+| REDIS_PORT                        | Port used for connecting to Redis instance                                   | number        |         |
+| REDIS_SSL_ENABLED                 | Whether SSL is enabled when connecting to Redis                              | boolean       |         |
+| NODO_HOSTNAME                     | Nodo connection host name                                                    | string        |         |
+| NODO_PER_PSP_URI                  | Nodo per PSP URI                                                             | string        |         |
+| NODE_FOR_PSP_URI                  | Nodo for PSP URI                                                             | string        |         |
+| NODO_READ_TIMEOUT                 | Http read timeout for all call made to Nodo                                  | number        |         |
+| NODO_CONNECTION_TIMEOUT           | Http connection timeout for all call made to Nodo                            | number        |         |
+| NODO_CONNECTION_STRING            | Connection string containing information used to make Nodo calls             | json (string) |         |
+| CARTS_MAX_ALLOWED_PAYMENT_NOTICES | Max allowed number of payment notices to be process for a POST carts request | number        |         |
 
 An example configuration of these environment variables is in the `.env.example` file.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ with redirects to [_pagoPA – Checkout_](https://checkout.pagopa.it).
 | NODO_READ_TIMEOUT                 | Http read timeout for all call made to Nodo                                  | number        |         |
 | NODO_CONNECTION_TIMEOUT           | Http connection timeout for all call made to Nodo                            | number        |         |
 | NODO_CONNECTION_STRING            | Connection string containing information used to make Nodo calls             | json (string) |         |
-| CARTS_MAX_ALLOWED_PAYMENT_NOTICES | Max allowed number of payment notices to be process for a POST carts request | number        |         |
+| CARTS_MAX_ALLOWED_PAYMENT_NOTICES | Max allowed number of payment notices to be processed for a POST carts request | number        |         |
 
 An example configuration of these environment variables is in the `.env.example` file.
 

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -31,9 +31,9 @@ microservice-chart:
     servicePort: 8080
   serviceAccount:
     create: false
-    annotations: {}
+    annotations: { }
     name: ""
-  podAnnotations: {}
+  podAnnotations: { }
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
@@ -78,6 +78,7 @@ microservice-chart:
     NODO_PER_PM_URI: /nodo/nodo-per-pm/v1/checkPosition
     NODO_READ_TIMEOUT: "10000"
     NODO_CONNECTION_TIMEOUT: "10000"
+    CARTS_MAX_ALLOWED_PAYMENT_NOTICES: "5"
   envSecret:
     REDIS_PASSWORD: redis-ecommerce-password
     APPLICATIONINSIGHTS_CONNECTION_STRING: applicationinsights-connection-string
@@ -85,8 +86,8 @@ microservice-chart:
   keyvault:
     name: "pagopa-d-ecommerce-kv"
     tenantId: "7788edaf-0346-4068-9d79-c868aed15b3d"
-  nodeSelector: {}
-  tolerations: []
+  nodeSelector: { }
+  tolerations: [ ]
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -20,6 +20,7 @@ microservice-chart:
       REDIS_HOST: pagopa-u-weu-ecommerce-redis.redis.cache.windows.net
       REDIS_PORT: "6380"
       REDIS_SSL_ENABLED: "true"
+      CARTS_MAX_ALLOWED_PAYMENT_NOTICES: "5"
     envSecret:
       REDIS_PASSWORD: redis-ecommerce-password
       APPLICATIONINSIGHTS_CONNECTION_STRING: applicationinsights-connection-string
@@ -53,9 +54,9 @@ microservice-chart:
     servicePort: 8080
   serviceAccount:
     create: false
-    annotations: {}
+    annotations: { }
     name: ""
-  podAnnotations: {}
+  podAnnotations: { }
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
@@ -90,6 +91,7 @@ microservice-chart:
     NODO_PER_PM_URI: /nodo/nodo-per-pm/v1/checkPosition
     NODO_READ_TIMEOUT: "10000"
     NODO_CONNECTION_TIMEOUT: "10000"
+    CARTS_MAX_ALLOWED_PAYMENT_NOTICES: "5"
   envSecret:
     REDIS_PASSWORD: redis-ecommerce-password
     APPLICATIONINSIGHTS_CONNECTION_STRING: applicationinsights-connection-string
@@ -97,8 +99,8 @@ microservice-chart:
   keyvault:
     name: "pagopa-u-ecommerce-kv"
     tenantId: "7788edaf-0346-4068-9d79-c868aed15b3d"
-  nodeSelector: {}
-  tolerations: []
+  nodeSelector: { }
+  tolerations: [ ]
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/requests/services/CartService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/requests/services/CartService.kt
@@ -34,6 +34,7 @@ class CartService(
   @Value("\${checkout.url}") private val checkoutUrl: String,
   @Autowired private val cartInfoRepository: CartInfoRepository,
   @Autowired private val nodoPerPmClient: NodoPerPmClient,
+  @Value("\${carts.max_allowed_payment_notices}") private val maxAllowedPaymentNotices: Int,
   private val defaultDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
 
@@ -41,11 +42,6 @@ class CartService(
    * Logger instance
    */
   var logger: Logger = LoggerFactory.getLogger(this.javaClass)
-
-  companion object CartServiceConstants {
-
-    const val MAX_ALLOWED_PAYMENT_NOTICES: Int = 1
-  }
 
   /*
    * Process input cartRequestDto:
@@ -57,7 +53,7 @@ class CartService(
     val receivedNotices = paymentsNotices.size
     logger.info("Received [$receivedNotices] payment notices")
 
-    return if (receivedNotices <= MAX_ALLOWED_PAYMENT_NOTICES) {
+    return if (receivedNotices <= maxAllowedPaymentNotices) {
       val paymentInfos =
         paymentsNotices.map {
           PaymentInfo(
@@ -114,7 +110,7 @@ class CartService(
       throw RestApiException(
         httpStatus = HttpStatus.UNPROCESSABLE_ENTITY,
         title = "Multiple payment notices not processable",
-        description = "Too many payment notices, expected max one")
+        description = "Too many payment notices, expected max $maxAllowedPaymentNotices")
     }
   }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,13 +5,15 @@ spring.redis.ssl=${REDIS_SSL_ENABLED}
 management.endpoint.health.probes.enabled=true
 #application configurations
 checkout.url=${CHECKOUT_URL}
-#configurazioni nodo
+#Nodo configurations
 nodo.hostname=${NODO_HOSTNAME}
 nodo.nodeforpsp.uri=${NODE_FOR_PSP_URI}
 nodo.nodoperpm.uri=${NODO_PER_PM_URI}
 nodo.readTimeout=${NODO_READ_TIMEOUT}
 nodo.connectionTimeout=${NODO_CONNECTION_TIMEOUT}
 nodo.connection.string=${NODO_CONNECTION_STRING}
+#Carts configurations
+carts.max_allowed_payment_notices=${CARTS_MAX_ALLOWED_PAYMENT_NOTICES}
 #fields to be obfuscated in case of bean validation failure
 fields_to_obscure={'emailNotice'}
 #disable null values serialization

--- a/src/test/kotlin/it/pagopa/ecommerce/payment/requests/controllers/CartsControllerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/payment/requests/controllers/CartsControllerTests.kt
@@ -53,6 +53,8 @@ class CartsControllerTests {
 
   @InjectMocks val cartsController: CartsController = CartsController()
 
+  private val cartsMaxAllowedPaymentNotices = 5
+
   @Test
   fun `post cart succeeded with one payment notice`() = runTest {
     val request = CartRequests.withOnePaymentNotice()
@@ -74,7 +76,7 @@ class CartsControllerTests {
   fun `post cart KO with multiple payment notices`() = runTest {
     val objectMapper = ObjectMapper()
     objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
-    val request = CartRequests.withMultiplePaymentNotice(5)
+    val request = CartRequests.withMultiplePaymentNotices(cartsMaxAllowedPaymentNotices)
     given(cartService.processCart(request))
       .willThrow(
         RestApiException(
@@ -103,7 +105,7 @@ class CartsControllerTests {
   fun `post cart KO with internal server error while invoke checkPosition`() = runTest {
     val objectMapper = ObjectMapper()
     objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
-    val request = CartRequests.withMultiplePaymentNotice(2)
+    val request = CartRequests.withMultiplePaymentNotices(cartsMaxAllowedPaymentNotices)
     given(cartService.processCart(request))
       .willThrow(CheckPositionErrorException(httpStatus = HttpStatus.INTERNAL_SERVER_ERROR))
     val errorResponse = ProblemJsonDto(status = 502, title = "Bad gateway")
@@ -123,7 +125,7 @@ class CartsControllerTests {
   fun `post cart KO with 404 while invoke checkPosition`() = runTest {
     val objectMapper = ObjectMapper()
     objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
-    val request = CartRequests.withMultiplePaymentNotice(2)
+    val request = CartRequests.withMultiplePaymentNotices(cartsMaxAllowedPaymentNotices)
     given(cartService.processCart(request))
       .willThrow(CheckPositionErrorException(httpStatus = HttpStatus.NOT_FOUND))
     val errorResponse = ProblemJsonDto(status = 500, title = "Internal server error")
@@ -143,7 +145,7 @@ class CartsControllerTests {
   fun `post cart KO with 400 while invoke checkPosition`() = runTest {
     val objectMapper = ObjectMapper()
     objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
-    val request = CartRequests.withMultiplePaymentNotice(2)
+    val request = CartRequests.withMultiplePaymentNotices(cartsMaxAllowedPaymentNotices)
     given(cartService.processCart(request))
       .willThrow(CheckPositionErrorException(httpStatus = HttpStatus.UNPROCESSABLE_ENTITY))
     val errorResponse = ProblemJsonDto(status = 422, title = "Invalid payment info")

--- a/src/test/kotlin/it/pagopa/ecommerce/payment/requests/controllers/CartsControllerTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/payment/requests/controllers/CartsControllerTests.kt
@@ -74,7 +74,7 @@ class CartsControllerTests {
   fun `post cart KO with multiple payment notices`() = runTest {
     val objectMapper = ObjectMapper()
     objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
-    val request = CartRequests.withMultiplePaymentNotice()
+    val request = CartRequests.withMultiplePaymentNotice(5)
     given(cartService.processCart(request))
       .willThrow(
         RestApiException(
@@ -103,7 +103,7 @@ class CartsControllerTests {
   fun `post cart KO with internal server error while invoke checkPosition`() = runTest {
     val objectMapper = ObjectMapper()
     objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
-    val request = CartRequests.withMultiplePaymentNotice()
+    val request = CartRequests.withMultiplePaymentNotice(2)
     given(cartService.processCart(request))
       .willThrow(CheckPositionErrorException(httpStatus = HttpStatus.INTERNAL_SERVER_ERROR))
     val errorResponse = ProblemJsonDto(status = 502, title = "Bad gateway")
@@ -123,7 +123,7 @@ class CartsControllerTests {
   fun `post cart KO with 404 while invoke checkPosition`() = runTest {
     val objectMapper = ObjectMapper()
     objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
-    val request = CartRequests.withMultiplePaymentNotice()
+    val request = CartRequests.withMultiplePaymentNotice(2)
     given(cartService.processCart(request))
       .willThrow(CheckPositionErrorException(httpStatus = HttpStatus.NOT_FOUND))
     val errorResponse = ProblemJsonDto(status = 500, title = "Internal server error")
@@ -143,7 +143,7 @@ class CartsControllerTests {
   fun `post cart KO with 400 while invoke checkPosition`() = runTest {
     val objectMapper = ObjectMapper()
     objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
-    val request = CartRequests.withMultiplePaymentNotice()
+    val request = CartRequests.withMultiplePaymentNotice(2)
     given(cartService.processCart(request))
       .willThrow(CheckPositionErrorException(httpStatus = HttpStatus.UNPROCESSABLE_ENTITY))
     val errorResponse = ProblemJsonDto(status = 422, title = "Invalid payment info")

--- a/src/test/kotlin/it/pagopa/ecommerce/payment/requests/services/CartsServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/payment/requests/services/CartsServiceTests.kt
@@ -28,8 +28,13 @@ class CartsServiceTests {
 
   private val cartInfoRepository: CartInfoRepository = mock()
   private val nodoPerPmClient: NodoPerPmClient = mock()
+  private val cartsMaxAllowedPaymentNotices = 5
   private val cartService: CartService =
-    CartService("${TEST_CHECKOUT_URL}/c/{0}", cartInfoRepository, nodoPerPmClient, 5)
+    CartService(
+      "${TEST_CHECKOUT_URL}/c/{0}",
+      cartInfoRepository,
+      nodoPerPmClient,
+      cartsMaxAllowedPaymentNotices)
 
   @Test
   fun `post cart succeeded with one payment notice`() = runTest {
@@ -65,7 +70,7 @@ class CartsServiceTests {
 
   @Test
   fun `post cart ko with multiple payment notices`() = runTest {
-    val request = CartRequests.withMultiplePaymentNotice(6)
+    val request = CartRequests.withMultiplePaymentNotices(cartsMaxAllowedPaymentNotices + 1)
     assertThrows<RestApiException> { cartService.processCart(request) }
   }
 

--- a/src/test/kotlin/it/pagopa/ecommerce/payment/requests/services/CartsServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/payment/requests/services/CartsServiceTests.kt
@@ -29,7 +29,7 @@ class CartsServiceTests {
   private val cartInfoRepository: CartInfoRepository = mock()
   private val nodoPerPmClient: NodoPerPmClient = mock()
   private val cartService: CartService =
-    CartService("${TEST_CHECKOUT_URL}/c/{0}", cartInfoRepository, nodoPerPmClient)
+    CartService("${TEST_CHECKOUT_URL}/c/{0}", cartInfoRepository, nodoPerPmClient, 5)
 
   @Test
   fun `post cart succeeded with one payment notice`() = runTest {
@@ -65,7 +65,7 @@ class CartsServiceTests {
 
   @Test
   fun `post cart ko with multiple payment notices`() = runTest {
-    val request = CartRequests.withMultiplePaymentNotice()
+    val request = CartRequests.withMultiplePaymentNotice(6)
     assertThrows<RestApiException> { cartService.processCart(request) }
   }
 

--- a/src/test/kotlin/it/pagopa/ecommerce/payment/requests/tests/utils/CartRequests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/payment/requests/tests/utils/CartRequests.kt
@@ -27,22 +27,20 @@ object CartRequests {
       emailNotice = "my_email@mail.it")
   }
 
-  fun withMultiplePaymentNotice(): CartRequestDto {
+  fun withMultiplePaymentNotice(paymentNoticesNumber: Int): CartRequestDto {
+    val paymentNotices = ArrayList<PaymentNoticeDto>()
+    repeat(paymentNoticesNumber) {
+      paymentNotices.add(
+        PaymentNoticeDto(
+          noticeNumber = "302000100440009420",
+          fiscalCode = "77777777777",
+          amount = 10000,
+          companyName = "companyName",
+          description = "description"))
+    }
+
     return CartRequestDto(
-      paymentNotices =
-        listOf(
-          PaymentNoticeDto(
-            noticeNumber = "302000100440009420",
-            fiscalCode = "77777777777",
-            amount = 10000,
-            companyName = "companyName",
-            description = "description"),
-          PaymentNoticeDto(
-            noticeNumber = "302000100440009421",
-            fiscalCode = "77777777777",
-            amount = 10000,
-            companyName = "companyName",
-            description = "description")),
+      paymentNotices = paymentNotices,
       returnUrls =
         CartRequestReturnUrlsDto(
           returnOkUrl = URI("www.comune.di.prova.it/pagopa/success.html"),

--- a/src/test/kotlin/it/pagopa/ecommerce/payment/requests/tests/utils/CartRequests.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/payment/requests/tests/utils/CartRequests.kt
@@ -27,7 +27,7 @@ object CartRequests {
       emailNotice = "my_email@mail.it")
   }
 
-  fun withMultiplePaymentNotice(paymentNoticesNumber: Int): CartRequestDto {
+  fun withMultiplePaymentNotices(paymentNoticesNumber: Int): CartRequestDto {
     val paymentNotices = ArrayList<PaymentNoticeDto>()
     repeat(paymentNoticesNumber) {
       paymentNotices.add(


### PR DESCRIPTION
Ecommerce local env alignment: https://github.com/pagopa/pagopa-ecommerce-local/pull/69
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Parameterized POST carts max allowed payment notices number by `CARTS_MAX_ALLOWED_PAYMENT_NOTICES` env variable
<!--- Describe your changes in detail -->

#### Motivation and Context
This modification is needed in order to let handle a parameterized max number of payment notices from a POST carts
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.