### PR TITLE
fix(rptId) CHK-1761 fix rpt id regex

### DIFF
--- a/api-spec/payment-requests-api.yaml
+++ b/api-spec/payment-requests-api.yaml
@@ -158,7 +158,7 @@ components:
         rptId:
           description: Digital payment request id
           type: string
-          pattern: '([a-zA-Z\d]{1,35})|(RF\d{2}[a-zA-Z\d]{1,21})'
+          pattern: '^([0-9]{29})$'
         paFiscalCode:
           description: Fiscal code associated to the payment notice
           type: string


### PR DESCRIPTION
Update the rpt id regex according to the document definition [numero avviso](https://pagopa.atlassian.net/wiki/spaces/PAG/pages/132808762/Numero+Avviso) e [pa cf](https://www.agenziaentrate.gov.it/portale/web/guest/schede/istanze/codice-fiscale-modello-aa5_6/scheda-info-cf-aa5_6-enti-e-pa). The first document asserts that the notice number is composed by 18 digits. The second(from Agenzia delle Entrate) asserts that the fiscal code is composed by 11 digits. So the rptId is composed exactly by 29 digits

#### List of Changes

Change the RptId regex

#### Motivation and Context

Using standard regex for rptId definition

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.