### PR TITLE
feat: [CHK-3776] workload identity support and helm chart v7

### DIFF
--- a/.devops/azure-templates/helm-microservice-chart-deploy.yml
+++ b/.devops/azure-templates/helm-microservice-chart-deploy.yml
@@ -56,7 +56,10 @@ steps:
       install: true
       waitForExecution: ${{ parameters.WAIT_FOR_EXECUTION }}
       arguments: ${{ parameters.ARGUMENTS }}
-      overrideValues: microservice-chart.image.tag=${{ parameters.GREEN_VERSION }},microservice-chart.canaryDelivery.create=${{ parameters.DO_BLUE_GREEN_DEPLOY }},microservice-chart.canaryDelivery.deployment.image.tag=${{ parameters.BLUE_VERSION }}
+      ${{ if eq(parameters['DO_BLUE_GREEN_DEPLOY'], True) }}:
+        overrideValues: microservice-chart.image.tag=${{ parameters.GREEN_VERSION }},microservice-chart.canaryDelivery.create=true,microservice-chart.canaryDelivery.image.tag=${{ parameters.BLUE_VERSION }},microservice-chart.fullnameOverride=beta-pagopa-ecommerce-payment-requests-service
+      ${{ else }}:
+        overrideValues: microservice-chart.image.tag=${{ parameters.GREEN_VERSION }},microservice-chart.canaryDelivery.create=false
   - template: ./chart-current-version.yml
   - ${{ if ne(parameters['APPINSIGHTS_SERVICE_CONN'], 'none') }}:
       - task: AzureCLI@2

--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -129,7 +129,6 @@ stages:
                 - template: azure-templates/helm-microservice-chart-deploy.yml
                   parameters:
                     DO_DEPLOY: true
-                    DO_BLUE_GREEN_DEPLOY: true
                     ENV: 'DEV'
                     KUBERNETES_SERVICE_CONN: $(DEV_KUBERNETES_SERVICE_CONN)
                     NAMESPACE: ecommerce
@@ -227,7 +226,7 @@ stages:
                     ENV: 'UAT'
                     KUBERNETES_SERVICE_CONN: $(UAT_KUBERNETES_SERVICE_CONN)
                     NAMESPACE: ecommerce
-                    APP_NAME: $(K8S_IMAGE_REPOSITORY_NAME)
+                    APP_NAME: beta-$(K8S_IMAGE_REPOSITORY_NAME)
                     VALUE_FILE: "helm/values-uat.yaml"
                     GREEN_VERSION: $(green_app_version)
                     BLUE_VERSION: $(Build.SourceVersion)
@@ -501,7 +500,7 @@ stages:
                     ENV: 'PROD'
                     KUBERNETES_SERVICE_CONN: $(PROD_KUBERNETES_SERVICE_CONN)
                     NAMESPACE: ecommerce
-                    APP_NAME: $(K8S_IMAGE_REPOSITORY_NAME)
+                    APP_NAME: beta-$(K8S_IMAGE_REPOSITORY_NAME)
                     VALUE_FILE: "helm/values-prod.yaml"
                     GREEN_VERSION: $(app_version)
                     BLUE_VERSION: $(Build.SourceVersion)

--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: microservice-chart
   repository: https://pagopa.github.io/aks-microservice-chart-blueprint
-  version: 2.3.1
-digest: sha256:92b42c64847373faa6bf054181be2d7ee61e8b6b6d6a5552bf1479691aa95df3
-generated: "2023-01-25T23:04:46.718526+01:00"
+  version: 7.4.0
+digest: sha256:ba6c74f4d1b23251f9256f33bbc5ac6eaaf586569c0b43e37ad413f6d36ceabe
+generated: "2025-03-07T15:40:45.226657+01:00"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -6,5 +6,5 @@ version: 1.5.0
 appVersion: 1.5.0
 dependencies:
   - name: microservice-chart
-    version: 2.3.1
+    version: 7.4.0
     repository: "https://pagopa.github.io/aks-microservice-chart-blueprint"

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -3,26 +3,22 @@ microservice-chart:
   nameOverride: ""
   fullnameOverride: ""
   canaryDelivery:
-    create: true
+    create: false
     ingress:
-      create: true
-      canary:
-        type: bluegreen
-    service:
-      create: true
-    deployment:
-      create: true
-      image:
-        repository: pagopadcommonacr.azurecr.io/pagopaecommercepaymentrequestsservice
-        tag: "latest"
-        pullPolicy: Always
-      envConfig:
-        NODO_HOSTNAME: https://api.dev.platform.pagopa.it
-        ECS_SERVICE_NAME: pagopa-ecommerce-payment-requests-service-blue
-        CHECKOUT_URL: https://api.dev.platform.pagopa.it/ecommerce/checkout/v1/carts/{0}/redirect?clientId={1}
-  deployment:
-    create: true
-    replicas: 1
+      bluegreen: true
+      #set canary deployment with traffic balancing see https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#canary for more info
+      header: true
+      headerName: deployment
+      headerValue: blue
+      weightPercent: 10
+    image:
+      repository: pagopadcommonacr.azurecr.io/pagopaecommercepaymentrequestsservice
+      tag: "latest"
+    envConfig:
+      NODO_HOSTNAME: https://api.dev.platform.pagopa.it
+      ECS_SERVICE_NAME: pagopa-ecommerce-payment-requests-service-blue
+      CHECKOUT_URL: https://api.dev.platform.pagopa.it/ecommerce/checkout/v1/carts/{0}/redirect?clientId={1}
+    envSecret: {}
   livenessProbe:
     httpGet:
       path: /actuator/health/liveness
@@ -50,8 +46,8 @@ microservice-chart:
     servicePort: 8080
   serviceAccount:
     create: false
-    annotations: {}
-    name: ""
+    annotations: { }
+    name: "ecommerce-workload-identity"
   podAnnotations: {}
   podSecurityContext:
     seccompProfile:
@@ -132,3 +128,5 @@ microservice-chart:
                 operator: In
                 values:
                   - user
+  azure:
+    workloadIdentityClientId: 1be61b58-24e2-49c8-b401-89ebd004bf2e

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -5,35 +5,19 @@ microservice-chart:
   canaryDelivery:
     create: false
     ingress:
-      create: true
-      canary:
-        type: bluegreen
-    service:
-      create: true
-    deployment:
-      create: true
-      image:
-        repository: pagopapcommonacr.azurecr.io/pagopaecommercepaymentrequestsservice
-        tag: "latest"
-        pullPolicy: Always
+      bluegreen: false
+      #set canary deployment with traffic balancing see https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#canary for more info
+      header: true
+      headerName: deployment
+      headerValue: blue
+      weightPercent: 10
+    image:
+      repository: pagopapcommonacr.azurecr.io/pagopaecommercepaymentrequestsservice
+      tag: "latest"
     envConfig:
-      REDIS_PORT: "6380"
-      REDIS_SSL_ENABLED: "true"
-      CARTS_MAX_ALLOWED_PAYMENT_NOTICES: "5"
       ECS_SERVICE_NAME: pagopa-ecommerce-payment-requests-service-blue
-      ECS_SERVICE_ENVIRONMENT: "prod"
       OTEL_RESOURCE_ATTRIBUTES: "service.name=pagopa-ecommerce-payment-requests-service-blue,deployment.environment=prod"
-      OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector.elastic-system.svc:4317"
-      OTEL_TRACES_EXPORTER: otlp
-      OTEL_METRICS_EXPORTER: otlp
-      OTEL_LOGS_EXPORTER: none
-      OTEL_TRACES_SAMPLER: "always_on"
-      PERSONAL_DATA_VAULT_API_BASE_PATH: "https://api.tokenizer.pdv.pagopa.it/tokenizer/v1"
-    envSecret:
-      REDIS_PASSWORD: redis-ecommerce-access-key
-      REDIS_HOST: redis-ecommerce-hostname
-      OTEL_EXPORTER_OTLP_HEADERS: elastic-otel-token-header
-      PERSONAL_DATA_VAULT_API_KEY: personal-data-vault-api-key
+    envSecret: {}
   image:
     repository: pagopapcommonacr.azurecr.io/pagopaecommercepaymentrequestsservice
     tag: "1.5.0"
@@ -67,8 +51,8 @@ microservice-chart:
     servicePort: 8080
   serviceAccount:
     create: false
-    annotations: {}
-    name: ""
+    annotations: { }
+    name: "ecommerce-workload-identity"
   podAnnotations: {}
   podSecurityContext:
     seccompProfile:
@@ -148,3 +132,5 @@ microservice-chart:
                 app.kubernetes.io/instance: pagopaecommercepaymentrequestsservice
             namespaces: ["ecommerce"]
             topologyKey: topology.kubernetes.io/zone
+  azure:
+    workloadIdentityClientId: "d5614882-90dd-47a1-aad1-cdf295201469"

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -5,35 +5,19 @@ microservice-chart:
   canaryDelivery:
     create: false
     ingress:
-      create: true
-      canary:
-        type: bluegreen
-    service:
-      create: true
-    deployment:
-      create: true
-      image:
-        repository: pagopaucommonacr.azurecr.io/pagopaecommercepaymentrequestsservice
-        tag: "latest"
-        pullPolicy: Always
+      bluegreen: false
+      #set canary deployment with traffic balancing see https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#canary for more info
+      header: true
+      headerName: deployment
+      headerValue: blue
+      weightPercent: 10
+    image:
+      repository: pagopaucommonacr.azurecr.io/pagopaecommercepaymentrequestsservice
+      tag: "latest"
     envConfig:
-      REDIS_PORT: "6380"
-      REDIS_SSL_ENABLED: "true"
-      CHECKOUT_URL: https://api.uat.platform.pagopa.it/ecommerce/checkout/v1/carts/{0}/redirect?clientId={1}
-      CARTS_MAX_ALLOWED_PAYMENT_NOTICES: "5"
       OTEL_RESOURCE_ATTRIBUTES: "service.name=pagopa-ecommerce-payment-requests-service-blue,deployment.environment=uat"
-      OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector.elastic-system.svc:4317"
-      OTEL_TRACES_EXPORTER: otlp
-      OTEL_METRICS_EXPORTER: otlp
-      OTEL_LOGS_EXPORTER: none
-      OTEL_TRACES_SAMPLER: "always_on"
       ECS_SERVICE_NAME: pagopa-ecommerce-payment-requests-service-blue
-      ECS_SERVICE_ENVIRONMENT: "uat"
-      PERSONAL_DATA_VAULT_API_BASE_PATH: "https://api.uat.tokenizer.pdv.pagopa.it/tokenizer/v1"
-    envSecret:
-      REDIS_PASSWORD: redis-ecommerce-access-key
-      REDIS_HOST: redis-ecommerce-hostname
-      PERSONAL_DATA_VAULT_API_KEY: personal-data-vault-api-key
+    envSecret: {}
   image:
     repository: pagopaucommonacr.azurecr.io/pagopaecommercepaymentrequestsservice
     tag: "1.5.0"
@@ -67,8 +51,8 @@ microservice-chart:
     servicePort: 8080
   serviceAccount:
     create: false
-    annotations: {}
-    name: ""
+    annotations: { }
+    name: "ecommerce-workload-identity"
   podAnnotations: {}
   podSecurityContext:
     seccompProfile:
@@ -139,3 +123,5 @@ microservice-chart:
                 operator: In
                 values:
                   - user
+  azure:
+    workloadIdentityClientId: 449c5b65-f368-487a-881a-b03676420c53


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Upgrade to helm chart 7 performing the following modifications:
- chat version update from 2.3.1 to 7.4.0
- canaryDelivery parameter update to the new template (adding canary section)
- add workload identity refs for each environment specifying the azure workload identity client id and service account name for each env
- modified the deploy pipeline logic based on the `DO_BLUE_GREEN_DEPLOY` env var
<!--- Describe your changes in detail -->

#### Motivation and Context
Those modification are needed in order to make ecommerce payment requests service use workload identities instead of deprecated pod identity.
Also, env variables were cleaned and the deploy pipeline now takes into consideration the blue/green deploy preferences
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
- `--dry-run` diff checkers for blue/green deployments
- Deploy on dev
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
