### PR TITLE
fix: release url

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/payment/requests/controllers/CartsController.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/requests/controllers/CartsController.kt
@@ -14,6 +14,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatusCode
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Mono
@@ -22,6 +24,11 @@ import reactor.core.publisher.Mono
 class CartsController(private val webClient: WebClient = WebClient.create()) : CartsApi {
   @Autowired private lateinit var cartService: CartService
 
+  @RequestMapping(
+    method = [RequestMethod.POST],
+    value = ["/carts", "/carts/"],
+    produces = ["application/json"],
+    consumes = ["application/json"])
   override suspend fun postCarts(
     xClientId: ClientIdDto,
     cartRequestDto: CartRequestDto


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Accept POST carts requests with trailing slash
<!--- Describe your changes in detail -->

#### Motivation and Context
In spring boot 2.x trailing slash were trimmed by default.
This results in http request with both /a/b/c/ and /a/b/c path to be accepted and mapped to /a/b/c
After upgrade to 3.x this default behavior was dropped (see [here](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#spring-mvc-and-webflux-url-matching-changes)) make the trailing slash to be propagated to the controller.
Since some client was integrated with eCommerce and perform api calls with trailing slash both paths have been make accepted.

Note for reviewers: the springboot doc suggested migration guide method to accept both paths using the `setUseTrailingSlashMatch` relies on a deprecated method, so instead of using this deprecated method the path with trailing slash have been forcibly added to the annotation controller
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local test + junit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.